### PR TITLE
fix issue #9703

### DIFF
--- a/bokehjs/src/lib/models/glyphs/image_url.ts
+++ b/bokehjs/src/lib/models/glyphs/image_url.ts
@@ -193,9 +193,18 @@ export class ImageURLView extends XYGlyphView {
 
     if (angle[i]) {
       ctx.translate(sxi, syi)
+      
+      //rotation about center of image
+      ctx.translate(sw[i]/2, sh[i]/2)
       ctx.rotate(angle[i])
+      ctx.translate(-sw[i]/2, -sh[i]/2)
+
       ctx.drawImage(image, 0, 0, sw[i], sh[i])
+      
+      ctx.translate(sw[i]/2, sh[i]/2)
       ctx.rotate(-angle[i])
+      ctx.translate(-sw[i]/2, -sh[i]/2)      
+      
       ctx.translate(-sxi, -syi)
     } else
       ctx.drawImage(image, sxi, syi, sw[i], sh[i])


### PR DESCRIPTION
Rotation of image about center when using angle and anchor [combined] in image_url.

All pull requests must have an associated issue in the issue tracker. If there
isn't one, please go open an issue describing the defect, deficiency or desired
feature. You can read more about our issue and PR processes in the
[wiki](https://github.com/bokeh/bokeh/wiki/BEP-1:-Issues-and-PRs-management).

- [ ] issues: fixes #xxxx
- [ ] tests added / passed
- [ ] release document entry (if new feature or API change)
